### PR TITLE
Refactor: Move percentage text out of SVG overlays

### DIFF
--- a/components/Hourglass.tsx
+++ b/components/Hourglass.tsx
@@ -82,12 +82,12 @@ const Hourglass: React.FC<HourglassProps> = ({
             mask={`url(#${maskIdBottom})`}
           />
         </svg>
-        <div 
-          className="absolute inset-0 flex items-center justify-center text-xl sm:text-2xl font-bold"
-          style={{ color: percentageColor }}
-        >
-          {clampedPercentage.toFixed(1)}%
-        </div>
+      </div>
+      <div
+        className="mt-2 text-xl sm:text-2xl font-bold"
+        style={{ color: percentageColor }}
+      >
+        {clampedPercentage.toFixed(1)}%
       </div>
       
       {details && (

--- a/components/RadialSlice.tsx
+++ b/components/RadialSlice.tsx
@@ -62,12 +62,12 @@ const RadialSlice: React.FC<RadialSliceProps> = ({
             />
           )}
         </svg>
-        <div 
-          className="absolute inset-0 flex items-center justify-center text-xl sm:text-2xl font-bold"
-          style={{ color: percentageColor }}
-        >
-          {clampedPercentage.toFixed(1)}%
-        </div>
+      </div>
+      <div
+        className="mt-2 text-xl sm:text-2xl font-bold"
+        style={{ color: percentageColor }}
+      >
+        {clampedPercentage.toFixed(1)}%
       </div>
       
       {details && (

--- a/components/TimeOrbit.tsx
+++ b/components/TimeOrbit.tsx
@@ -54,12 +54,12 @@ const TimeOrbit: React.FC<TimeOrbitProps> = ({
             // style={{ filter: `drop-shadow(0 0 3px ${planetShadow})` }} // Simplified or removed shadow
           />
         </svg>
-        <div 
-          className="absolute inset-0 flex items-center justify-center text-2xl font-bold"
-          style={{ color: percentageColor }}
-        >
-          {clampedPercentage.toFixed(1)}%
-        </div>
+      </div>
+      <div
+        className="mt-2 text-xl sm:text-2xl font-bold"
+        style={{ color: percentageColor }}
+      >
+        {clampedPercentage.toFixed(1)}%
       </div>
       
       {details && (


### PR DESCRIPTION
I modified the Hourglass, TimeOrbit, and RadialSlice components to prevent text from overlapping with visualizations.

- In Hourglass.tsx, TimeOrbit.tsx, and RadialSlice.tsx, the percentage display was previously absolutely positioned over the SVG element.
- I moved the percentage display to a separate div below the SVG container.
- I made the styling (font size, weight, and margin) for the percentage display consistent with other visualization components like PixelGrid and TimeSpiral.
- This improves readability and provides a cleaner visual separation between the graphical representation and its corresponding textual data.